### PR TITLE
Fix scrolling bug in infinite table

### DIFF
--- a/IPDatePicker.podspec
+++ b/IPDatePicker.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'IPDatePicker'
-  s.version          = '0.3.0'
+  s.version          = '0.4.0'
   s.summary          = 'A customizable alternative to UIDatePicker.'
 
   s.description      = <<-DESC

--- a/IPDatePicker/Classes/InfiniteTableView.swift
+++ b/IPDatePicker/Classes/InfiniteTableView.swift
@@ -174,6 +174,16 @@ final class InfiniteTableView: UIView, UITableViewDataSource, UITableViewDelegat
     // MARK: - Centering
 
     func centerOnItem(_ item: Int, animated: Bool) {
+        // TODO: Refactor this to better handle the finite case (or remove that completely)
+        // There is also an issue where this condition is met more often than expected.
+        // It is not having any obvious adverse effects so we will leave it as-is
+        if scrollMode == .finite {
+            let offsetY = (CGFloat(item) + 0.5) * rowHeight - bounds.height * 0.5
+            setContentOffset(CGPoint(x: 0.0, y: offsetY), animated: animated)
+
+            return
+        }
+
         resetCurrentOffsetToPrimary()
         if animated {
             layoutIfNeeded()


### PR DESCRIPTION
# Summary 
Bug found and fixed by Andrew Dolce.

This PR adds different centering behavior when the scroll mode is in the finite case. Ideally, we would break out the finite case into its own class but we'll leave a TODO for now.

Changes made for PR:
https://usva-gheprod01.bose.com/DrowsyHypno/Hypno_iOS/pull/318